### PR TITLE
Makefile bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,13 @@ $(PINK):
 	make -C $(THIRD_PATH)/pink/ __PERF=$(__PERF)
 
 $(GLOG):
+ifeq ($(SO_PATH), $(wildcard $(SO_PATH)))
+       @echo "$(SO_PATH) exist."
+else
+       @echo "$(SO_PATH) not exist."
+       mkdir $(SO_PATH)
+endif
+
 	#if [ -d $(THIRD_PATH)/glog/.libs ]; then 
 	if [ ! -f $(GLOG) ]; then \
 		cd $(THIRD_PATH)/glog; \

--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,12 @@ $(PINK):
 	make -C $(THIRD_PATH)/pink/ __PERF=$(__PERF)
 
 $(GLOG):
+
 ifeq ($(SO_PATH), $(wildcard $(SO_PATH)))
-       @echo "$(SO_PATH) exist."
+	@echo "$(SO_PATH) exist."
 else
-       @echo "$(SO_PATH) not exist."
-       mkdir $(SO_PATH)
+	@echo "$(SO_PATH) not exist."
+	mkdir $(SO_PATH)
 endif
 
 	#if [ -d $(THIRD_PATH)/glog/.libs ]; then 


### PR DESCRIPTION
在Ubuntu系统上，`/lib/ubuntu`没有被创建，随后的  `cp  $(CURPATH)/third/glog/.libs/libglog.so.0 $(SO_PATH)` 无效。