### PR TITLE
Makefile bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,18 +135,16 @@ $(PINK):
 	make -C $(THIRD_PATH)/pink/ __PERF=$(__PERF)
 
 $(GLOG):
-
 ifeq ($(SO_PATH), $(wildcard $(SO_PATH)))
 	@echo "$(SO_PATH) exist."
 else
 	@echo "$(SO_PATH) not exist."
 	mkdir $(SO_PATH)
 endif
-
 	#if [ -d $(THIRD_PATH)/glog/.libs ]; then 
 	if [ ! -f $(GLOG) ]; then \
 		cd $(THIRD_PATH)/glog; \
-		autoreconf -ivf; ./configure; make; echo '*' > $(CURPATH)/third/glog/.gitignore; cp $(CURPATH)/third/glog/.libs/libglog.so.0 $(SO_PATH); \
+		autoreconf -ivf; ./configure; make; echo '*' > .gitignore; cp .libs/libglog.so.0 $(SO_PATH); \
 	fi; 
 	
 clean: 


### PR DESCRIPTION
这行代码[#L148](https://github.com/Qihoo360/zeppelin/blob/master/Makefile#L148) 已经进入`third/glog`目录，后续的`echo`, `cp`操作都会因为路径问题无效.

@flabby @CatKang @KernelMaker please review it, thanks.