### PR TITLE
Move SendToPeer to ZPBinlogSendThread.

### DIFF
--- a/src/node/zp_binlog_sender.h
+++ b/src/node/zp_binlog_sender.h
@@ -20,6 +20,7 @@
 #include "slash/include/slash_mutex.h"
 #include "slash/include/env.h"
 #include "pink/include/pink_thread.h"
+#include "pink/include/pink_cli.h"
 
 #include "include/client.pb.h"
 #include "include/zp_meta_utils.h"
@@ -170,9 +171,11 @@ class ZPBinlogSendThread : public pink::Thread  {
  public:
   explicit ZPBinlogSendThread(ZPBinlogSendTaskPool *pool);
   virtual ~ZPBinlogSendThread();
-
+  // Peer Client
+  Status SendToPeer(const Node &node, const client::SyncRequest &msg);
  private:
   ZPBinlogSendTaskPool *pool_;
+  std::unordered_map<std::string, pink::PinkCli*> peers_;
   virtual void* ThreadMain();
   bool RenewPeerLease(ZPBinlogSendTask* task);
 };

--- a/src/node/zp_data_server.h
+++ b/src/node/zp_data_server.h
@@ -138,8 +138,6 @@ class ZPDataServer  {
   void DumpTablePartitions();
   void DumpBinlogSendTask();
 
-  // Peer Client
-  Status SendToPeer(const Node &node, const client::SyncRequest &msg);
 
   // Backgroud thread
   void BGSaveTaskSchedule(void (*function)(void*), void* arg);
@@ -190,8 +188,6 @@ class ZPDataServer  {
   std::shared_ptr<Table> GetTable(const std::string &table_name);
 
   // Binlog Send related
-  slash::Mutex mutex_peers_;
-  std::unordered_map<std::string, pink::PinkCli*> peers_;
   ZPBinlogSendTaskPool binlog_send_pool_;
   std::vector<ZPBinlogSendThread*> binlog_send_workers_;
 


### PR DESCRIPTION
When master send binlog to slave, it does't need to wait the lock